### PR TITLE
Go version

### DIFF
--- a/dotnet_task_memory_usage/go.mod
+++ b/dotnet_task_memory_usage/go.mod
@@ -1,0 +1,1 @@
+module taskmemusage

--- a/dotnet_task_memory_usage/main.go
+++ b/dotnet_task_memory_usage/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+func main() {
+	numTasks := flag.Int("numtasks", 1, "number of tasks to run")
+	sleep := flag.Duration("sleep", 1*time.Second, "duration to sleep")
+	flag.Parse() // updates the pointers above to whatever values are provided
+	log.Printf("numTasks=%d sleep=%s\n", *numTasks, *sleep)
+
+	log.Printf("OS threads for Goroutine worker pool: %d", runtime.GOMAXPROCS(0))
+
+	scoreboard := Scoreboard{lastDump: time.Now()}
+
+	for i := 0; i < *numTasks; i++ {
+		go workTask(&scoreboard, *sleep)
+	}
+
+	scoreboard.PollScores()
+}
+
+func workTask(scoreboard *Scoreboard, sleep time.Duration) {
+	for {
+		time.Sleep(sleep)
+		scoreboard.AddHit()
+	}
+}
+
+type Scoreboard struct {
+	lastDump time.Time
+	score    int64
+}
+
+func (s *Scoreboard) AddHit() {
+	atomic.AddInt64(&s.score, 1)
+}
+
+func (s *Scoreboard) PollScores() {
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+		totalHits := atomic.LoadInt64(&s.score)
+		elapsed := time.Since(s.lastDump)
+		s.lastDump = time.Now()
+		log.Printf("elapsed=%s totalHits=%d\n", elapsed, totalHits)
+		log.Println(getMemInfo())
+		atomic.StoreInt64(&s.score, 0)
+	}
+}
+
+func getMemInfo() string {
+	data, err := ioutil.ReadFile("/proc/self/statm")
+	if err != nil {
+		log.Panicln("could not read from statm")
+	}
+	dataStr := strings.Split(string(data), " ")
+
+	// gcalive represents the amount of memory that's actually alive,
+	// rather than just the amount of rss memory that the runtime
+	// keeps around to amortize allocations.
+	memstats := runtime.MemStats{}
+	runtime.ReadMemStats(&memstats)
+	gcalive := memstats.HeapInuse / 4096 //make it in terms of 4K pages to be consistent
+
+	return fmt.Sprintf("(NB: 4K pages) vmsize=%s vmrss=%s gcalive=%d", dataStr[0], dataStr[1], gcalive)
+}


### PR DESCRIPTION
Hey, I don't expect this to be merged, but I thought you might be interested in my findings, and this seemed as good of a way to present them as any other. I saw your code [when it topped HN earlier today](https://news.ycombinator.com/item?id=19008224) and I thought it was neat. I ran this code on my desktop, which has an R7 2700X and 32GB of RAM.

I modified both examples to only run for 10 loops of the `PollScores` function to allow the `time` command to be used to measure total CPU consumption. I also took these measurements using the non-locking C# version I provided that uses atomics, since that should be more efficient than locking to update.

<details>
<summary>
Go: (click to expand)
</summary>

```
~/w/t/dotnet_task_memory_usage (master)> time -v go run main.go -numtasks 1000000 -sleep 1s
2019/01/26 23:05:34 numTasks=1000000 sleep=1s
2019/01/26 23:05:34 OS threads for Goroutine worker pool: 16
2019/01/26 23:05:36 elapsed=2.130295621s totalHits=941952
2019/01/26 23:05:36 (NB: 4K pages) vmsize=674840 vmrss=647215 gcalive=122314
2019/01/26 23:05:37 elapsed=1.000402966s totalHits=999998
2019/01/26 23:05:37 (NB: 4K pages) vmsize=674840 vmrss=647215 gcalive=122318
2019/01/26 23:05:38 elapsed=1.03070284s totalHits=973482
2019/01/26 23:05:38 (NB: 4K pages) vmsize=674840 vmrss=647215 gcalive=122318
2019/01/26 23:05:39 elapsed=1.000568978s totalHits=1001207
2019/01/26 23:05:39 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122318
2019/01/26 23:05:40 elapsed=1.000290892s totalHits=1000088
2019/01/26 23:05:40 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122320
2019/01/26 23:05:41 elapsed=1.000431424s totalHits=1000066
2019/01/26 23:05:41 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122320
2019/01/26 23:05:42 elapsed=1.000254997s totalHits=999988
2019/01/26 23:05:42 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122320
2019/01/26 23:05:43 elapsed=1.000278036s totalHits=1000003
2019/01/26 23:05:43 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122320
2019/01/26 23:05:44 elapsed=1.000235687s totalHits=999997
2019/01/26 23:05:44 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122320
2019/01/26 23:05:45 elapsed=1.01672797s totalHits=994893
2019/01/26 23:05:45 (NB: 4K pages) vmsize=674840 vmrss=647257 gcalive=122322
        Command being timed: "go run main.go -numtasks 1000000 -sleep 1s"
        User time (seconds): 24.85
        System time (seconds): 3.42
        Percent of CPU this job got: 246%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.45
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 2591620
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 681764
        Voluntary context switches: 580345
        Involuntary context switches: 62126
        Swaps: 0
        File system inputs: 0
        File system outputs: 3208
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details>

<details>
<summary>
C#: (click to expand)
</summary>

```
~/w/t/dotnet_task_memory_usage (master)> time -v dotnet ./bin/Release/netcoreapp2.2/dotnet_massive_async.dll 1000000 1
MinThreads: 16, 16
MaxThreads: 32767, 1000
elapsed=00:00:01.6743737 totalHits=260548
(NB: 4K pages) vmsize=1044691 vmrss=107573
elapsed=00:00:01.5251142 totalHits=1013241
(NB: 4K pages) vmsize=1429134 vmrss=157602
elapsed=00:00:01.5680060 totalHits=1001691
(NB: 4K pages) vmsize=1429134 vmrss=208486
elapsed=00:00:01.6982014 totalHits=974933
(NB: 4K pages) vmsize=1510953 vmrss=202729
elapsed=00:00:01.8096049 totalHits=1011643
(NB: 4K pages) vmsize=1510953 vmrss=200368
elapsed=00:00:01.8837871 totalHits=1003029
(NB: 4K pages) vmsize=1510953 vmrss=196544
elapsed=00:00:01.8471250 totalHits=1002489
(NB: 4K pages) vmsize=1510953 vmrss=178307
elapsed=00:00:01.8911205 totalHits=1011743
(NB: 4K pages) vmsize=1510953 vmrss=168310
elapsed=00:00:01.9215449 totalHits=1000190
(NB: 4K pages) vmsize=1510953 vmrss=168983
elapsed=00:00:01.8231014 totalHits=1005390
(NB: 4K pages) vmsize=1510953 vmrss=217063
        Command being timed: "dotnet ./bin/Release/netcoreapp2.2/dotnet_massive_async.dll 1000000 1"
        User time (seconds): 80.62
        System time (seconds): 2.26
        Percent of CPU this job got: 467%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:17.73
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 926496
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 802465
        Voluntary context switches: 184900
        Involuntary context switches: 22146
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
</details>



It's interesting to note that the C# code is suffering major delays, since each Poll loop is sleeping for about 1.8 seconds instead of 1 second, just due to how busy the scheduler is, I guess.

The `time` command reports that the C# code used 80.6 seconds of `User time` to perform the computations, where the Go code used just 24.85 seconds of `User time`.

When I scaled the problem up to 10,000,000 tasks, the differences were just escalated further.

<details>
<summary>
Go: (click to expand)
</summary>

```
2019/01/26 23:14:28 numTasks=10000000 sleep=1s                                                                                                                                                                                                                                                                         
2019/01/26 23:14:28 OS threads for Goroutine worker pool: 16                                                                                                                                                                                                                                                           
2019/01/26 23:14:40 elapsed=12.483542066s totalHits=10148425                                                                                                                                                                                                                                                           
2019/01/26 23:14:40 (NB: 4K pages) vmsize=6491968 vmrss=6467264 gcalive=1217382                                                                                                                                                                                                                                        
2019/01/26 23:14:42 elapsed=1.549151955s totalHits=9195975                                                                                                                                                                                                                                                             
2019/01/26 23:14:42 (NB: 4K pages) vmsize=6491968 vmrss=6473715 gcalive=1224490                                                                                                                                                                                                                                        
2019/01/26 23:14:44 elapsed=1.935536194s totalHits=10379516                                                                                                                                                                                                                                                            
2019/01/26 23:14:44 (NB: 4K pages) vmsize=6508880 vmrss=6475549 gcalive=1226266                                                                                                                                                                                                                                        
2019/01/26 23:14:46 elapsed=2.092334769s totalHits=10479330                                                                                                                                                                                                                                                            
2019/01/26 23:14:46 (NB: 4K pages) vmsize=6508880 vmrss=6477397 gcalive=1228042                                                                                                                                                                                                                                        
2019/01/26 23:14:48 elapsed=1.94436646s totalHits=9171490                                                                                                                                                                                                                                                              
2019/01/26 23:14:48 (NB: 4K pages) vmsize=6508880 vmrss=6479045 gcalive=1229820                                                                                                                                                                                                                                        
2019/01/26 23:14:50 elapsed=2.5513006s totalHits=11260521                                                                                                                                                                                                                                                              
2019/01/26 23:14:50 (NB: 4K pages) vmsize=6508880 vmrss=6479243 gcalive=1229820                                                                                                                                                                                                                                        
2019/01/26 23:14:53 elapsed=2.28181096s totalHits=9579832                                                                                                                                                                                                                                                              
2019/01/26 23:14:53 (NB: 4K pages) vmsize=6508880 vmrss=6480827 gcalive=1231596                                                                                                                                                                                                                                        
2019/01/26 23:14:55 elapsed=2.273252968s totalHits=9122101                                                                                                                                                                                                                                                             
2019/01/26 23:14:55 (NB: 4K pages) vmsize=6508880 vmrss=6480893 gcalive=1231596                                                                                                                                                                                                                                        
2019/01/26 23:14:57 elapsed=2.564331171s totalHits=9863432                                                                                                                                                                                                                                                             
2019/01/26 23:14:57 (NB: 4K pages) vmsize=6508880 vmrss=6481025 gcalive=1231596                                                                                                                                                                                                                                        
2019/01/26 23:15:00 elapsed=2.427882065s totalHits=8979567                                                                                                                                                                                                                                                             
2019/01/26 23:15:00 (NB: 4K pages) vmsize=6508880 vmrss=6482543 gcalive=1233374                                                                                                                                                                                                                                        
        Command being timed: "go run main.go -numtasks 10000000 -sleep 1s"                                                                                                                                                                                                                                             
        User time (seconds): 234.38                                                                                                                                                                                                                                                                                    
        System time (seconds): 32.51
        Percent of CPU this job got: 813%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:32.81
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 25934028
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 6620767
        Voluntary context switches: 4788910
        Involuntary context switches: 46169
        Swaps: 0
        File system inputs: 8
        File system outputs: 3096
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details>

<details>
<summary>
C#: (click to expand)
</summary>

```
MinThreads: 16, 16
MaxThreads: 32767, 1000
elapsed=00:00:35.4027919 totalHits=16865748
(NB: 4K pages) vmsize=2858234 vmrss=1552803
elapsed=00:00:16.4148456 totalHits=9983328
(NB: 4K pages) vmsize=3418178 vmrss=2080102
elapsed=00:00:17.9912734 totalHits=10003379
(NB: 4K pages) vmsize=3379245 vmrss=1843466
elapsed=00:00:18.9871312 totalHits=9996053
(NB: 4K pages) vmsize=3377196 vmrss=1898915
elapsed=00:00:19.2695100 totalHits=9995400
(NB: 4K pages) vmsize=3278884 vmrss=1872226
elapsed=00:00:18.7996579 totalHits=10004775
(NB: 4K pages) vmsize=3442730 vmrss=1834358
elapsed=00:00:20.3040826 totalHits=9988126
(NB: 4K pages) vmsize=3442730 vmrss=1763434
elapsed=00:00:20.2314619 totalHits=10013563
(NB: 4K pages) vmsize=3409968 vmrss=1761947
elapsed=00:00:20.2617460 totalHits=10020761
(NB: 4K pages) vmsize=3442738 vmrss=1854769
elapsed=00:00:20.5523381 totalHits=9999310
(NB: 4K pages) vmsize=3442734 vmrss=1653391
        Command being timed: "dotnet ./bin/Release/netcoreapp2.2/dotnet_massive_async.dll 10000000 1"
        User time (seconds): 927.00
        System time (seconds): 23.67
        Percent of CPU this job got: 456%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:28.44
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 9313104
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 8391903
        Voluntary context switches: 2126404
        Involuntary context switches: 160983
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details>




In the 10,000,000 task case, the Go Poll loop started to fall behind, taking about 2.2 seconds per loop, but the C# one fell to about 19 seconds per loop iteration. The final `User time` was 927 seconds for C# and 234 seconds for Go.

Just some interesting stuff. Go obviously allocates a bit more virtual memory, especially since each task is stackful, but its task scheduler does a nice job. 32GB of RAM was barely enough for 10M tasks in Go, since the Go version used 26GB, where the C# version used only about 9.3GB of RAM for 10M tasks.