### PR TITLE
Using Tiered Compilation

### DIFF
--- a/dotnet_client_server/project.csproj
+++ b/dotnet_client_server/project.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TieredCompilation>true</TieredCompilation>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Enabled tiered compilation.
Should be measured but usually it provides a better performance profile. As a matter of fact this is a default setting in .NET Core 3.0.